### PR TITLE
Add awsSessionToken to make temporary security credentials work

### DIFF
--- a/src/main/java/vc/inreach/aws/request/AWSSigner.java
+++ b/src/main/java/vc/inreach/aws/request/AWSSigner.java
@@ -26,6 +26,7 @@ public class AWSSigner {
     private static final String HMAC_SHA256 = "HmacSHA256";
     private static final String SLASH = "/";
     private static final String X_AMZ_DATE = "x-amz-date";
+    private static final String X_AMZ_SECURITY_TOKEN = "x-amz-security-token";
     private static final String RETURN = "\n";
     private static final String AWS4_HMAC_SHA256 = "AWS4-HMAC-SHA256\n";
     private static final String AWS4_REQUEST = "/aws4_request";
@@ -57,6 +58,7 @@ public class AWSSigner {
 
     private final String awsAccessKeyId;
     private final String awsSecretKey;
+    private final String awsSessionToken;
     private final String region;
     private final String service;
     private final Supplier<LocalDateTime> clock;
@@ -66,8 +68,18 @@ public class AWSSigner {
                      String region,
                      String service,
                      Supplier<LocalDateTime> clock) {
+        this(awsAccessKeyId, awsSecretKey, null, region, service, clock);
+    }
+
+    public AWSSigner(String awsAccessKeyId,
+                     String awsSecretKey,
+                     String awsSessionToken,
+                     String region,
+                     String service,
+                     Supplier<LocalDateTime> clock) {
         this.awsAccessKeyId = awsAccessKeyId;
         this.awsSecretKey = awsSecretKey;
+        this.awsSessionToken = awsSessionToken;
         this.region = region;
         this.service = service;
         this.clock = clock;
@@ -78,6 +90,9 @@ public class AWSSigner {
         final ImmutableMap.Builder<String, Object> result = ImmutableMap.builder();
         result.putAll(headers);
         result.put(X_AMZ_DATE, now.format(BASIC_TIME_FORMAT));
+        if (awsSessionToken != null) {
+            result.put(X_AMZ_SECURITY_TOKEN, awsSessionToken);
+        }
 
         final StringBuilder headersString = new StringBuilder();
         final ImmutableList.Builder<String> signedHeaders = ImmutableList.builder();


### PR DESCRIPTION
First things first; Nice work on this one! Found it super useful, got it working on the first attempt. :+1: 

This pr adds a parameter `awsSessionToken` that needs to be sent along as an unsigned header `X-Amz-Security-Token` when [temporary access key id and secret access keys are used when interacting with the aws apis](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html#RequestWithSTS). 

Excerpt:
> Include the IAM session token that is part of the temporary security credentials. You include the session token as an authorization header to the request—for example, as the X-Amz-Security-Token header. (The session token is not part of the information that's used to create the signature.)

An example of this would be when calling the aws es service with jest from a lambda with access key id and secret access keys provided through iam roles. Access key id, secret access key and the session token can be found for lambdas from the environment variables `AWS_ACCESS_KEY`, `AWS_SECRET_KEY` and `AWS_SESSION_TOKEN` respectively