### PR TITLE
Unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ hs_err_pid*
 .idea
 *.iml
 target
+/.classpath
+/.project
+/.settings

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>3.2.0</version>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/vc/inreach/aws/request/test/AWSSignerTest.java
+++ b/src/test/java/vc/inreach/aws/request/test/AWSSignerTest.java
@@ -1,6 +1,7 @@
 package vc.inreach.aws.request.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static java.lang.String.format;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
@@ -19,34 +20,58 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMap;
 
 public class AWSSignerTest {
+    /**
+     * Test case given in AWS Signing Test Suite (http://docs.aws.amazon.com/general/latest/gr/signature-v4-test-suite.html)
+     * (get-vanilla-query.*)
+     * 
+     * @throws Exception
+     */
     @Test
     public void testGetVanilla() throws Exception {
         // GIVEN
+        // Credentials
         String awsAccessKey = "AKIDEXAMPLE";
         String awsSecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
         String region = "us-east-1";
         String service = "host";
-        Supplier<LocalDateTime> clock = () -> LocalDateTime.of(2011, 9, 9, 23, 36, 0);
         AWSCredentials credentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey);
         AWSCredentialsProvider awsCredentialsProvider = new StaticCredentialsProvider(credentials);
-
-        // WHEN
-        AWSSigner signer = new AWSSigner(awsCredentialsProvider, region, service, clock);
+        
+        // HTTP request
+        String host = "host.foo.com";
         String uri = "/";
         String method = "GET";
+        
+        // Date
+        Supplier<LocalDateTime> clock = () -> LocalDateTime.of(2011, 9, 9, 23, 36, 0);
+        // weird date : 09 Sep 2011 is a friday, not a monday
+        String date = "Mon, 09 Sep 2011 23:36:00 GMT";
+
+        // WHEN
+        // The request is signed
+        AWSSigner signer = new AWSSigner(awsCredentialsProvider, region, service, clock);
         Map<String, String> queryParams = new HashMap<>();
         Map<String, Object> headers = ImmutableMap.<String, Object> builder()
-                .put("Date", "Mon, 09 Sep 2011 23:36:00 GMT")
-                .put("Host", "host.foo.com")
+                .put("Date", date)
+                .put("Host", host)
                 .build();
         Optional<byte[]> payload = Optional.absent();
         Map<String, Object> signedHeaders = signer.getSignedHeaders(uri, method, queryParams, headers, payload);
 
         // THEN
-        assertThat(signedHeaders)
-                .containsKey("Authorization");
-        assertThat(signedHeaders.get("Authorization"))
-                .isEqualTo(
-                        "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470");
+        // The signature must match the expected signature
+        String expectedSignature = "b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470";
+        String expectedAuthorizationHeader = format(
+                "AWS4-HMAC-SHA256 Credential=%s/20110909/%s/%s/aws4_request, SignedHeaders=date;host, Signature=%s",
+                awsAccessKey, region, service, expectedSignature
+                );
+        
+        assertThat(signedHeaders).containsKey("Authorization");
+        assertThat(signedHeaders.get("Authorization")).isEqualTo(expectedAuthorizationHeader);
+        assertThat(signedHeaders).containsKey("Host");
+        assertThat(signedHeaders.get("Host")).isEqualTo(host);
+        assertThat(signedHeaders).containsKey("Date");
+        assertThat(signedHeaders.get("Date")).isEqualTo(date);
+        assertThat(signedHeaders).doesNotContainKey("X-Amz-Date");
     }
 }

--- a/src/test/java/vc/inreach/aws/request/test/AWSSignerTest.java
+++ b/src/test/java/vc/inreach/aws/request/test/AWSSignerTest.java
@@ -1,0 +1,52 @@
+package vc.inreach.aws.request.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import vc.inreach.aws.request.AWSSigner;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.internal.StaticCredentialsProvider;
+import com.google.common.base.Optional;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableMap;
+
+public class AWSSignerTest {
+    @Test
+    public void testGetVanilla() throws Exception {
+        // GIVEN
+        String awsAccessKey = "AKIDEXAMPLE";
+        String awsSecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+        String region = "us-east-1";
+        String service = "host";
+        Supplier<LocalDateTime> clock = () -> LocalDateTime.of(2011, 9, 9, 23, 36, 0);
+        AWSCredentials credentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey);
+        AWSCredentialsProvider awsCredentialsProvider = new StaticCredentialsProvider(credentials);
+
+        // WHEN
+        AWSSigner signer = new AWSSigner(awsCredentialsProvider, region, service, clock);
+        String uri = "/";
+        String method = "GET";
+        Map<String, String> queryParams = new HashMap<>();
+        Map<String, Object> headers = ImmutableMap.<String, Object> builder()
+                .put("Date", "Mon, 09 Sep 2011 23:36:00 GMT")
+                .put("Host", "host.foo.com")
+                .build();
+        Optional<byte[]> payload = Optional.absent();
+        Map<String, Object> signedHeaders = signer.getSignedHeaders(uri, method, queryParams, headers, payload);
+
+        // THEN
+        assertThat(signedHeaders)
+                .containsKey("Authorization");
+        assertThat(signedHeaders.get("Authorization"))
+                .isEqualTo(
+                        "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470");
+    }
+}

--- a/src/test/java/vc/inreach/aws/request/test/AWSSignerTest.java
+++ b/src/test/java/vc/inreach/aws/request/test/AWSSignerTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static java.lang.String.format;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -26,6 +25,10 @@ public class AWSSignerTest {
      * Test case given in AWS Signing Test Suite (http://docs.aws.amazon.com/general/latest/gr/signature-v4-test-suite.html)
      * (get-vanilla-query.*)
      * 
+     * GET / http/1.1
+     * Date:Mon, 09 Sep 2011 23:36:00 GMT
+     * Host:host.foo.com
+     * 
      * @throws Exception
      */
     @Test
@@ -39,30 +42,93 @@ public class AWSSignerTest {
         String region = "us-east-1";
         String service = "host";
         
-        // HTTP request
-        String host = "host.foo.com";
-        String uri = "/";
-        String method = "GET";
-        
         // Date
         Supplier<LocalDateTime> clock = () -> LocalDateTime.of(2011, 9, 9, 23, 36, 0);
         // weird date : 09 Sep 2011 is a friday, not a monday
         String date = "Mon, 09 Sep 2011 23:36:00 GMT";
-
-        // WHEN
-        // The request is signed
-        AWSSigner signer = new AWSSigner(awsCredentialsProvider, region, service, clock);
-        Map<String, String> queryParams = new HashMap<>();
+        
+        // HTTP request
+        String host = "host.foo.com";
+        String uri = "/";
+        String method = "GET";
+        Map<String, String> queryParams = ImmutableMap.<String, String> builder()
+                .build();
         Map<String, Object> headers = ImmutableMap.<String, Object> builder()
                 .put("Date", date)
                 .put("Host", host)
                 .build();
         Optional<byte[]> payload = Optional.absent();
+
+        // WHEN
+        // The request is signed
+        AWSSigner signer = new AWSSigner(awsCredentialsProvider, region, service, clock);
         Map<String, Object> signedHeaders = signer.getSignedHeaders(uri, method, queryParams, headers, payload);
 
         // THEN
         // The signature must match the expected signature
         String expectedSignature = "b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470";
+        String expectedAuthorizationHeader = format(
+                "AWS4-HMAC-SHA256 Credential=%s/20110909/%s/%s/aws4_request, SignedHeaders=date;host, Signature=%s",
+                awsAccessKey, region, service, expectedSignature
+                );
+        
+        TreeMap<String, Object> caseInsensitiveSignedHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        caseInsensitiveSignedHeaders.putAll(signedHeaders);
+        assertThat(caseInsensitiveSignedHeaders).containsKey("Authorization");
+        assertThat(caseInsensitiveSignedHeaders.get("Authorization")).isEqualTo(expectedAuthorizationHeader);
+        assertThat(caseInsensitiveSignedHeaders).containsKey("Host");
+        assertThat(caseInsensitiveSignedHeaders.get("Host")).isEqualTo(host);
+        assertThat(caseInsensitiveSignedHeaders).containsKey("Date");
+        assertThat(caseInsensitiveSignedHeaders.get("Date")).isEqualTo(date);
+        assertThat(caseInsensitiveSignedHeaders).doesNotContainKey("X-Amz-Date");
+    }
+    /**
+     * Test case given in AWS Signing Test Suite (http://docs.aws.amazon.com/general/latest/gr/signature-v4-test-suite.html)
+     * (get-vanilla-query.*)
+     * 
+     * POST /?foo=bar http/1.1
+     * Date:Mon, 09 Sep 2011 23:36:00 GMT
+     * Host:host.foo.com
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testPostVanillaQuery() throws Exception {
+        // GIVEN
+        // Credentials
+        String awsAccessKey = "AKIDEXAMPLE";
+        String awsSecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+        AWSCredentials credentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey);
+        AWSCredentialsProvider awsCredentialsProvider = new StaticCredentialsProvider(credentials);
+        String region = "us-east-1";
+        String service = "host";
+        
+        // Date
+        Supplier<LocalDateTime> clock = () -> LocalDateTime.of(2011, 9, 9, 23, 36, 0);
+        // weird date : 09 Sep 2011 is a friday, not a monday
+        String date = "Mon, 09 Sep 2011 23:36:00 GMT";
+        
+        // HTTP request
+        String host = "host.foo.com";
+        String uri = "/";
+        String method = "POST";
+        Map<String, String> queryParams = ImmutableMap.<String, String> builder()
+                .put("foo", "bar")
+                .build();
+        Map<String, Object> headers = ImmutableMap.<String, Object> builder()
+                .put("Date", date)
+                .put("Host", host)
+                .build();
+        Optional<byte[]> payload = Optional.absent();
+
+        // WHEN
+        // The request is signed
+        AWSSigner signer = new AWSSigner(awsCredentialsProvider, region, service, clock);
+        Map<String, Object> signedHeaders = signer.getSignedHeaders(uri, method, queryParams, headers, payload);
+
+        // THEN
+        // The signature must match the expected signature
+        String expectedSignature = "b6e3b79003ce0743a491606ba1035a804593b0efb1e20a11cba83f8c25a57a92";
         String expectedAuthorizationHeader = format(
                 "AWS4-HMAC-SHA256 Credential=%s/20110909/%s/%s/aws4_request, SignedHeaders=date;host, Signature=%s",
                 awsAccessKey, region, service, expectedSignature
@@ -90,24 +156,25 @@ public class AWSSignerTest {
         String region = "us-east-1";
         String service = "host";
         
-        // HTTP request
-        String host = "host.foo.com";
-        String uri = "/";
-        String method = "GET";
-        
         // Date
         Supplier<LocalDateTime> clock = () -> LocalDateTime.of(2011, 9, 9, 23, 36, 0);
         // weird date : 09 Sep 2011 is a friday, not a monday
         String date = "20110909T233600Z";
-
-        // WHEN
-        // The request is signed
-        AWSSigner signer = new AWSSigner(awsCredentialsProvider, region, service, clock);
-        Map<String, String> queryParams = new HashMap<>();
+        
+        // HTTP request
+        String host = "host.foo.com";
+        String uri = "/";
+        String method = "GET";
+        Map<String, String> queryParams = ImmutableMap.<String, String> builder()
+                .build();
         Map<String, Object> headers = ImmutableMap.<String, Object> builder()
                 .put("Host", host)
                 .build();
         Optional<byte[]> payload = Optional.absent();
+
+        // WHEN
+        // The request is signed
+        AWSSigner signer = new AWSSigner(awsCredentialsProvider, region, service, clock);
         Map<String, Object> signedHeaders = signer.getSignedHeaders(uri, method, queryParams, headers, payload);
 
         // THEN
@@ -141,25 +208,26 @@ public class AWSSignerTest {
         String region = "us-east-1";
         String service = "host";
         
-        // HTTP request
-        String host = "host.foo.com";
-        String uri = "/";
-        String method = "GET";
-        
         // Date
         Supplier<LocalDateTime> clock = () -> LocalDateTime.of(2011, 9, 9, 23, 36, 0);
         // weird date : 09 Sep 2011 is a friday, not a monday
         String date = "Mon, 09 Sep 2011 23:36:00 GMT";
-
-        // WHEN
-        // The request is signed
-        AWSSigner signer = new AWSSigner(awsCredentialsProvider, region, service, clock);
-        Map<String, String> queryParams = new HashMap<>();
+        
+        // HTTP request
+        String host = "host.foo.com";
+        String uri = "/";
+        String method = "GET";
+        Map<String, String> queryParams = ImmutableMap.<String, String> builder()
+                .build();
         Map<String, Object> headers = ImmutableMap.<String, Object> builder()
                 .put("Date", date)
                 .put("Host", host)
                 .build();
         Optional<byte[]> payload = Optional.absent();
+
+        // WHEN
+        // The request is signed
+        AWSSigner signer = new AWSSigner(awsCredentialsProvider, region, service, clock);
         Map<String, Object> signedHeaders = signer.getSignedHeaders(uri, method, queryParams, headers, payload);
 
         // THEN

--- a/src/test/java/vc/inreach/aws/request/test/AWSSignerTest.java
+++ b/src/test/java/vc/inreach/aws/request/test/AWSSignerTest.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableMap;
 public class AWSSignerTest {
     /**
      * Test case given in AWS Signing Test Suite (http://docs.aws.amazon.com/general/latest/gr/signature-v4-test-suite.html)
-     * (get-vanilla-query.*)
+     * (get-vanilla.*)
      * 
      * GET / http/1.1
      * Date:Mon, 09 Sep 2011 23:36:00 GMT
@@ -84,7 +84,7 @@ public class AWSSignerTest {
     }
     /**
      * Test case given in AWS Signing Test Suite (http://docs.aws.amazon.com/general/latest/gr/signature-v4-test-suite.html)
-     * (get-vanilla-query.*)
+     * (post-vanilla-query.*)
      * 
      * POST /?foo=bar http/1.1
      * Date:Mon, 09 Sep 2011 23:36:00 GMT


### PR DESCRIPTION
Hi.

I added a bunch of unit tests on AWSSigner.

I had to make some modifications in your code to handle cases where there is a "Date" header (see [AWS related documentation](http://docs.aws.amazon.com/general/latest/gr/sigv4-date-handling.html)). I also refactored a bit the signed headers Map creation to have case-insensitive keys.

The first 2 tests come from [AWS test suite](http://docs.aws.amazon.com/general/latest/gr/signature-v4-test-suite.html).
The 2 last tests are custom tests to ensure X-Amz-Date and X-Amz-Security-Token are correctly handled. The AWS test suite is missing these test cases (I created a case about it in AWS support).

The coverage is pretty good (94.9% of vc.inreach.aws.request.AWSSigner is covered, according to EclEmma).

Still need some tests on vc.inreach.aws.request.AWSSigningRequestInterceptor.

Cheers,
Eric.