### PR TITLE
Url-encode canonical path 

### DIFF
--- a/src/main/java/vc/inreach/aws/request/AWSSigner.java
+++ b/src/main/java/vc/inreach/aws/request/AWSSigner.java
@@ -3,6 +3,7 @@ package vc.inreach.aws.request;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSSessionCredentials;
+import com.amazonaws.util.SdkHttpUtils;
 import com.google.common.base.*;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -106,7 +107,7 @@ public class AWSSigner {
 
         final String signedHeaderKeys = JOINER.join(signedHeaders.build());
         final String canonicalRequest = method + RETURN +
-                uri + RETURN +
+		        SdkHttpUtils.urlEncode(SdkHttpUtils.urlEncode(uri, true), true) + RETURN +
                 queryParamsString(queryParams) + RETURN +
                 headersString.toString() + RETURN +
                 signedHeaderKeys + RETURN +


### PR DESCRIPTION
Fixes a bug in signing which occurs when trying to get an object from ES which has a URL-encodable id.

The canonical URL wasn't URL-encoded, which caused an invalid signature. It also needs to be doubly encoded, since AWS expects the `%` character to be encoded.

To test: index an ES object with an id of the form `1@foo`. Without this patch, the signing will fail.
 
See 
https://tools.ietf.org/html/rfc3986
https://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_the_percent_character