### PR TITLE
Fix for Get.Builder

### DIFF
--- a/src/main/java/vc/inreach/aws/request/AWSSigningRequestInterceptor.java
+++ b/src/main/java/vc/inreach/aws/request/AWSSigningRequestInterceptor.java
@@ -64,6 +64,12 @@ public class AWSSigningRequestInterceptor implements HttpRequestInterceptor {
         final ImmutableMap.Builder<String, Object> headers = ImmutableMap.builder();
 
         for (Header header : request.getAllHeaders()) {
+            if (header.getName().equals("Content-Length")) {
+        		if (Integer.parseInt(header.getValue()) == 0) {
+        			headers.put(header.getName(), "");
+        			continue;
+        		}
+        	}
             headers.put(header.getName(), header.getValue());
         }
 


### PR DESCRIPTION
When Content-Length is empty returns an empty string instead of 0. By default looks like HttpRequest returns 0 instead of an empty.

Reason for the change:
When trying to execute a Get.Builder it returns a miscalculated signature.

example code:

```
			Index index = new Index.Builder(source).index("twitter").type("tweet").id("1").build();
			client.execute(index);
			Get get = new Get.Builder("twitter", "1").type("tweet").build();
			JestResult result = client.execute(get);
			System.out.println(result.getJsonMap());
```
returns:

> {message=The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
> 
> The Canonical String for this request should have been
> 'GET
> /twitter/tweet/1
> 
> accept-encoding:gzip,deflate
> connection:close
> content-length:
> host:search-estest-q4hwvaz3g53iyvtuna5lasktge.eu-west-1.es.amazonaws.com
> user-agent:Apache-HttpClient/4.3.6 (java 1.5)
> x-amz-date:20160504T112524Z
> 
> accept-encoding;connection;content-length;host;user-agent;x-amz-date
> e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
> 
> The String-to-Sign should have been
> 'AWS4-HMAC-SHA256
> 20160504T112524Z
> 20160504/eu-west-1/es/aws4_request
> df0e51731c0896de283be958a4a1e7c277fd29f3b359e7ab850d9af959bf4b0f'
> }

checking the canonical string I saw that content-length was content-length:0 which made the miscalculation to occur.

Not sure if my code is the best approach for this issue. Feel free to execute a different fix.