### PR TITLE
Use urlFormParameterEscaper for query parameters

### DIFF
--- a/src/main/java/vc/inreach/aws/request/AWSSigner.java
+++ b/src/main/java/vc/inreach/aws/request/AWSSigner.java
@@ -65,7 +65,7 @@ public class AWSSigner {
     private static final String AUTHORIZATION = "Authorization";
     private static final String SESSION_TOKEN = "x-amz-security-token";
     private static final String DATE = "date";
-    private static final Escaper ESCAPER = UrlEscapers.urlPathSegmentEscaper();
+    private static final Escaper ESCAPER = UrlEscapers.urlFormParameterEscaper();
     private static final String POST = "POST";
 
     private final AWSCredentialsProvider credentialsProvider;

--- a/src/test/java/vc/inreach/aws/request/test/AWSSignerTest.java
+++ b/src/test/java/vc/inreach/aws/request/test/AWSSignerTest.java
@@ -251,4 +251,57 @@ public class AWSSignerTest {
         assertThat(caseInsensitiveSignedHeaders).containsKey("X-Amz-Security-Token");
         assertThat(caseInsensitiveSignedHeaders.get("X-Amz-Security-Token")).isEqualTo(sessionToken);
     }
+
+    @Test
+    public void testGetVanillaBase64QueryParam() throws Exception {
+        // GIVEN
+        // Credentials
+        String awsAccessKey = "AKIDEXAMPLE";
+        String awsSecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+        AWSCredentials credentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey);
+        AWSCredentialsProvider awsCredentialsProvider = new StaticCredentialsProvider(credentials);
+        String region = "us-east-1";
+        String service = "host";
+
+        // Date
+        Supplier<LocalDateTime> clock = () -> LocalDateTime.of(2011, 9, 9, 23, 36, 0);
+        // weird date : 09 Sep 2011 is a friday, not a monday
+        String date = "Mon, 09 Sep 2011 23:36:00 GMT";
+
+        // HTTP request
+        String host = "host.foo.com";
+        String uri = "/";
+        String method = "GET";
+        Multimap<String, String> queryParams = ImmutableListMultimap.<String, String>builder()
+                .put("scrollId", "dGVzdA===")
+                .build();
+        Map<String, Object> headers = ImmutableMap.<String, Object>builder()
+                .put("Date", date)
+                .put("Host", host + ":80")
+                .build();
+        Optional<byte[]> payload = Optional.absent();
+
+        // WHEN
+        // The request is signed
+        AWSSigner signer = new AWSSigner(awsCredentialsProvider, region, service, clock);
+        Map<String, Object> signedHeaders = signer.getSignedHeaders(uri, method, queryParams, headers, payload);
+
+        // THEN
+        // The signature must match the expected signature
+        String expectedSignature = "ebec182ae6456633a8fecbd2737e60d6aec6b0da9cfa5731457e71edec83fde3";
+        String expectedAuthorizationHeader = format(
+                "AWS4-HMAC-SHA256 Credential=%s/20110909/%s/%s/aws4_request, SignedHeaders=date;host, Signature=%s",
+                awsAccessKey, region, service, expectedSignature
+        );
+
+        TreeMap<String, Object> caseInsensitiveSignedHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        caseInsensitiveSignedHeaders.putAll(signedHeaders);
+        assertThat(caseInsensitiveSignedHeaders).containsKey("Authorization");
+        assertThat(caseInsensitiveSignedHeaders.get("Authorization")).isEqualTo(expectedAuthorizationHeader);
+        assertThat(caseInsensitiveSignedHeaders).containsKey("Host");
+        assertThat(caseInsensitiveSignedHeaders.get("Host")).isEqualTo(host);
+        assertThat(caseInsensitiveSignedHeaders).containsKey("Date");
+        assertThat(caseInsensitiveSignedHeaders.get("Date")).isEqualTo(date);
+        assertThat(caseInsensitiveSignedHeaders).doesNotContainKey("X-Amz-Date");
+    }
 }


### PR DESCRIPTION
queryParameters containing the equals sign are not encoded by the path encoder. This causes signature verification failures when using elasticsearch's scrollId with looks like a base64 encoded value.

09:32:28.035-0700 [qtp2125697331-13] ERROR c.c.k.e.ExceptionMapperDefault - unexpected exception
java.lang.RuntimeException: 403 Forbidden: {"message":"The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.\n\nThe Canonical String for this request should have been\n'GET\n/_search/scroll\nscroll=2m&scroll_id=cXVlcnlUaGVuRmV0Y2g7NTsyMjo2RU9JZ3hnb1R1bVN1YkEzb1ZZRk1BOzIzOjZFT0lneGdvVHVtU3ViQTNvVllGTUE7MjQ6NkVPSWd4Z29UdW1TdWJBM29WWUZNQTsyNTpEWWd6TkNvMVRVaXdNMEhQMnI4RGtBOzI1OjZFT0lneGdvVHVtU3ViQTNvVllGTUE7MDs%3D&size=1000\naccept-encoding:gzip,deflate\nconnection:close\ncontent-length:\nhost:search-distributionsvc-ed3-fzntidxlav75wev5czyyb7nqqi.us-east-1.es.amazonaws.com\nuser-agent:Apache-HttpClient/4.5.1 (Java/1.8.0_60)\nx-amz-date:20160615T163227Z\n\naccept-encoding;connection;content-length;host;user-agent;x-amz-date\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'\n\nThe String-to-Sign should have been\n'AWS4-HMAC-SHA256\n20160615T163227Z\n20160615/us-east-1/es/aws4_request\n59cb37f4636bff2474292317db44d3ad1a9fedc85b3efa3603582c362a47d99b'\n"}
