### PR TITLE
Fix for double uri encoding

### DIFF
--- a/src/main/java/vc/inreach/aws/request/AWSSigner.java
+++ b/src/main/java/vc/inreach/aws/request/AWSSigner.java
@@ -115,7 +115,7 @@ public class AWSSigner {
 
         final String signedHeaderKeys = JOINER.join(signedHeaders.build());
         final String canonicalRequest = method + RETURN +
-		        SdkHttpUtils.urlEncode(SdkHttpUtils.urlEncode(uri, true), true) + RETURN +
+		        SdkHttpUtils.urlEncode(uri, true) + RETURN +
                 queryParamsString(queryParams) + RETURN +
                 headersString.toString() + RETURN +
                 signedHeaderKeys + RETURN +


### PR DESCRIPTION
The URI was being double encoded causing signing errors when reserved characters appeared.

Discovered this while using Jest w/elasticsearch. The index wild card character of '*' was being converted to '%252A' when it should have simply been '%2A'.
