### PR TITLE
Issue #36 - Parameters with empty values

### DIFF
--- a/src/main/java/vc/inreach/aws/request/AWSSigningRequestInterceptor.java
+++ b/src/main/java/vc/inreach/aws/request/AWSSigningRequestInterceptor.java
@@ -52,11 +52,11 @@ public class AWSSigningRequestInterceptor implements HttpRequestInterceptor {
         if (! Strings.isNullOrEmpty(query)) {
             for (String pair : SPLITTER.split(query)) {
                 final int index = pair.indexOf('=');
-                if (index > 0 && pair.length() > index + 1) {
+                if (index > 0) {
                     final String key = pair.substring(0, index);
                     final String value = pair.substring(index + 1);
                     queryParams.put(key, value);
-                } else if (pair.length() > 0) {
+                } else {
                     queryParams.put(pair, "");
                 }
             }

--- a/src/test/java/vc/inreach/aws/request/AWSSigningRequestInterceptorTest.java
+++ b/src/test/java/vc/inreach/aws/request/AWSSigningRequestInterceptorTest.java
@@ -96,6 +96,37 @@ public class AWSSigningRequestInterceptorTest {
         verify(signer).getSignedHeaders(anyString(), anyString(), eq(queryParams), anyMapOf(String.class, Object.class), any(com.google.common.base.Optional.class));
     }
 
+    @Test
+    public void queryParamsSupportEmptyValues() throws Exception {
+        final String key = "a";
+        final String url = "http://someurl.com?" + key + "=";
+        final Multimap<String, String> queryParams = ImmutableListMultimap.of(key, "");
+
+        when(signer.getSignedHeaders(anyString(), anyString(), eq(queryParams), anyMapOf(String.class, Object.class), any(com.google.common.base.Optional.class))).thenReturn(ImmutableMap.of());
+        mockRequest(url);
+
+        interceptor.process(request, context);
+
+        verify(request).setHeaders(new Header[]{});
+        verify(signer).getSignedHeaders(anyString(), anyString(), eq(queryParams), anyMapOf(String.class, Object.class), any(com.google.common.base.Optional.class));
+    }
+
+    @Test
+    public void emptyQueryParams() throws Exception {
+        final String key = "a";
+        final String value = "b";
+        final String url = "http://someurl.com?" + key + "=" + value + "&";
+        final Multimap<String, String> queryParams = ImmutableListMultimap.of(key, value);
+
+        when(signer.getSignedHeaders(anyString(), anyString(), eq(queryParams), anyMapOf(String.class, Object.class), any(com.google.common.base.Optional.class))).thenReturn(ImmutableMap.of());
+        mockRequest(url);
+
+        interceptor.process(request, context);
+
+        verify(request).setHeaders(new Header[]{});
+        verify(signer).getSignedHeaders(anyString(), anyString(), eq(queryParams), anyMapOf(String.class, Object.class), any(com.google.common.base.Optional.class));
+    }
+
     private void mockRequest(String url) throws Exception {
         when(request.getURI()).thenReturn(new URI(url));
         when(request.getRequestLine()).thenReturn(new BasicRequestLine("GET", url, new ProtocolVersion("HTTP", 1, 1)));


### PR DESCRIPTION
Fixes signature if the request contains a parameter with an equals but an empty value. Also added a test for dangling ampersands as it's not obvious that the fix accounts for that case.